### PR TITLE
fix aot compilation

### DIFF
--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -36,11 +36,9 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
   @Input('spacer') spacerElement: HTMLElement | undefined;
   @Input('boundary') boundaryElement: HTMLElement | undefined;
 
-  @HostBinding('class.is-sticky')
-  private sticky = false;
+  @HostBinding('class.is-sticky') sticky = false;
 
-  @HostBinding('class.boundary-reached')
-  private boundaryReached = false;
+  @HostBinding('class.boundary-reached') boundaryReached = false;
 
 
   /**


### PR DESCRIPTION
This pull request makes this module usable with AOT compilation, for which the directive's `HostBinding` properties need to be public.
For more information see the discussions [here](https://github.com/angular/angular/issues/24034) and [here](https://github.com/angular/angular-cli/issues/5621).