### PR TITLE
fix(sticky-directive): fix element jumping

### DIFF
--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -44,6 +44,8 @@ export class StickyThingDirective implements OnInit, OnChanges, OnDestroy {
 
   @HostBinding('class.boundary-reached') boundaryReached = false;
 
+  private initialMarginTop: number;
+  private initialMarginBottom: number;
 
   /**
    * The field represents some position values in normal (not sticky) mode.
@@ -129,6 +131,7 @@ export class StickyThingDirective implements OnInit, OnChanges, OnDestroy {
     this.checkSetup();
 
     if (this.isEnabled) {
+      this.setInitialMargins();
       this.activate();
     }
   }
@@ -185,7 +188,8 @@ export class StickyThingDirective implements OnInit, OnChanges, OnDestroy {
     this.stickyElement.nativeElement.style.left = left + 'px';
     this.stickyElement.nativeElement.style.width = `${width}px`;
     if (this.spacerElement) {
-      this.spacerElement.style.height = `${height}px`;
+      const spacerHeight = this.initialMarginBottom + height + this.initialMarginTop;
+      this.spacerElement.style.height = `${spacerHeight}px`;
     }
   }
 
@@ -242,6 +246,11 @@ Then pass the spacer element as input:
     }
   }
 
+  private setInitialMargins(): void {
+    const stickyStyles = window.getComputedStyle(this.stickyElement.nativeElement);
+    this.initialMarginTop = parseInt(stickyStyles.marginTop, 10);
+    this.initialMarginBottom = parseInt(stickyStyles.marginBottom, 10);
+  }
 }
 
 // Thanks to https://stanko.github.io/javascript-get-element-offset/

--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -145,7 +145,7 @@ export class StickyThingDirective implements OnInit, OnChanges, OnDestroy {
     const stickyElementHeight = this.getComputedStyle(this.stickyElement.nativeElement).height;
     const reachedLowerEdge = this.boundaryElement && window.pageYOffset + stickyElementHeight + this.marginBottom >= (originalVals.bottomBoundary - this.marginTop);
     return {
-      isSticky: pageYOffset > originalVals.offsetY - this.marginTop,
+      isSticky: pageYOffset > originalVals.offsetY,
       reachedLowerEdge
     };
   }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -59,7 +59,7 @@
     <div class="row">
       <div class="col-6">
         <div #spacer3></div>
-        <div stickyThing="" [spacer]="spacer3" [boundary]="boundary3" marginTop="50">
+        <div stickyThing="" [spacer]="spacer3" [boundary]="boundary3" [marginTop]="50" [marginBottom]="50">
           <svg xmlns="http://www.w3.org/2000/svg" width="210mm" height="155mm"
                viewBox="0 0 210 155">
             <path


### PR DESCRIPTION
Fixed the calculations to determine the sticky status, thus fixing the bug mentioned [here](https://github.com/w11k/angular-sticky-things/pull/10#issuecomment-444082749).