### PR TITLE
feat(sticky-directive): allow recalculating offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export class SomeModule { }
 
 If a boundary element is defined, the sticky element scrolls only within the height of the boundary element and then stops. This is useful if you have multiple sticky elements since it prevents stacking. You can [take a look at the examples](https://w11k.github.io/angular-sticky-things/).
 ```html
-<div #boundary style="height:1000px;">
+<div #boundary>
   <div #spacer></div>
   <div stickyThing [spacer]="spacer" [boundary]="boundary">
     I am sticky but only inside #boundary!
@@ -91,15 +91,29 @@ An `enable` (default `true`) input can be used to dynamically activate or deacti
 
 A `marginTop` (default `0`) input can be used to add some top spacing to the sticky element, in case you don't want it to stick right at the top. It expects the `number` of pixels you want to use for the space. You can [take a look at the examples](https://w11k.github.io/angular-sticky-things/). Accordingly, `marginBottom` is available.
 
-
 ```html
-<div #boundary style="height:1000px;">
+<div #boundary>
   <div #spacer></div>
   <div stickyThing [spacer]="spacer" marginTop="30">
     I leave 30px of space to the top when I'm sticky!
   </div>
 </div>
 ```
+
+#### Recalculate offsets
+
+In case where the sticky element or any element above it changes height (e.g. because of translations or other dynamic content), a `recalculate()` method can be called to redetermine the element's offsets.
+
+```html
+<button (click)="stickyDirective.recalculate()">Recalculate offsets</button>
+<div #boundary>
+  <div #spacer></div>
+  <div stickyThing  [spacer]="spacer" #stickyDirective="stickyDirective">
+    I am sticky!
+  </div>
+</div>
+```
+
 
 
 ## Patron

--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -53,12 +53,12 @@ export class StickyThingDirective implements OnInit, OnChanges, OnDestroy {
    * The field represents some position values in normal (not sticky) mode.
    * If the browser size or the content of the page changes, this value must be recalculated.
    * */
-  private recalculate$ = new Subject<void>();
   private normalPosition$: Observable<StickyPositions>;
   private scroll$ = new Subject<any>();
   private scrollThrottled$: Observable<number>;
 
 
+  private recalculate$ = new Subject<void>();
   private resize$ = new Subject<void>();
   private redetermineThrottled$: Observable<void>;
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
 
 import {AppComponent} from './app.component';
-import {AngularStickyThingsModule} from '@w11k/angular-sticky-things';
+import {AngularStickyThingsModule} from '../../projects/angular-sticky-things/src/public_api';
 import {InfoComponent} from './info/info.component';
 import {DevComponent} from './dev/dev.component';
 import {HomeComponent} from './home/home.component';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
 
 import {AppComponent} from './app.component';
-import {AngularStickyThingsModule} from '../../projects/angular-sticky-things/src/public_api';
+import {AngularStickyThingsModule} from '@w11k/angular-sticky-things';
 import {InfoComponent} from './info/info.component';
 import {DevComponent} from './dev/dev.component';
 import {HomeComponent} from './home/home.component';

--- a/src/app/dev/dev.component.html
+++ b/src/app/dev/dev.component.html
@@ -3,8 +3,15 @@
   Set margin bottom: <input (change)="marginBottom=+($event.target.value)" [value]="marginBottom" id="bottom"
                             type="text"> <br>
   <button id="enable-btn" (click)="enabled = !enabled">{{enabled ? 'disable' : 'enable'}}</button>
+  <button id="enable-btn" (click)="inside.push(inside.length+1)">Add content inside</button>
+  <button id="enable-btn" (click)="outside.push(outside.length+1)">Add content outside</button>
+  <button id="enable-btn" (click)="stickyDirective.recalculate()">Recalculate offsets</button>
 </div>
 <div class="first" #boundary>
+  <p>Some initial content</p>
+  <p *ngFor="let item of outside">
+    New content {{ item }}
+  </p>
   <div class="container">
     <div class="row">
       <div class="col-6"></div>
@@ -12,6 +19,7 @@
         <div #spacer></div>
         <div
           class="some-thing-sticky"
+          #stickyDirective="stickyDirective"
           stickyThing=""
           [spacer]="spacer"
           [boundary]="boundary"
@@ -19,6 +27,9 @@
           [enable]="enabled"
           [marginBottom]="marginBottom"
         >Hello
+        <p *ngFor="let item of inside">
+          New content {{ item }}
+        </p>
         </div>
       </div>
     </div>

--- a/src/app/dev/dev.component.html
+++ b/src/app/dev/dev.component.html
@@ -2,10 +2,10 @@
   Set a margin top: <input (change)="marginTop=+($event.target.value)" [value]="marginTop" id="top" type="text"> <br>
   Set margin bottom: <input (change)="marginBottom=+($event.target.value)" [value]="marginBottom" id="bottom"
                             type="text"> <br>
-  <button id="enable-btn" (click)="enabled = !enabled">{{enabled ? 'disable' : 'enable'}}</button>
-  <button id="enable-btn" (click)="inside.push(inside.length+1)">Add content inside</button>
-  <button id="enable-btn" (click)="outside.push(outside.length+1)">Add content outside</button>
-  <button id="enable-btn" (click)="stickyDirective.recalculate()">Recalculate offsets</button>
+  <button id="enable-btn" type="button" (click)="enabled = !enabled">{{enabled ? 'disable' : 'enable'}}</button>
+  <button id="enable-btn" type="button" (click)="inside.push(inside.length+1)">Add content inside</button>
+  <button id="enable-btn" type="button" (click)="outside.push(outside.length+1)">Add content outside</button>
+  <button id="enable-btn" type="button" (click)="stickyDirective.recalculate()">Recalculate offsets</button>
 </div>
 <div class="first" #boundary>
   <p>Some initial content</p>

--- a/src/app/dev/dev.component.scss
+++ b/src/app/dev/dev.component.scss
@@ -24,10 +24,14 @@ $container-height: 500px;
 
 .some-thing-sticky {
   width: 100%;
-  height: $sticky-height;
+  // height: $sticky-height;
   background-color: #193441;
   color: #ffffff;
   text-align: center;
+}
+
+p:last-child {
+  margin-bottom: 0;
 }
 
 .debug-line {
@@ -55,9 +59,8 @@ $container-height: 500px;
 
 
 .fixed {
-  top: 0;
+  bottom: 5%;
   position: fixed;
-  left: 0;
   display: inline-block;
   background-color: #ffffff;
   padding: 5px;

--- a/src/app/dev/dev.component.ts
+++ b/src/app/dev/dev.component.ts
@@ -6,7 +6,8 @@ import {Component, OnInit} from '@angular/core';
   styleUrls: ['./dev.component.scss']
 })
 export class DevComponent implements OnInit {
-
+  inside = [];
+  outside = [];
   marginTop = 0;
   marginBottom = 0;
   enabled = true;


### PR DESCRIPTION
This PR addresses the issue discussed [here](https://github.com/w11k/angular-sticky-things/issues/14), exposing a `recalculate()` method that can be used to recalculate the positions at which the element has to become sticky.