### PR TITLE
fix update height for spacer element

### DIFF
--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -227,7 +227,7 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
     return el.getBoundingClientRect();
   }
 
-  private determineStatus(originalVals: StickyPositions, pageYOffset: number, marginTop: number, marginBottom: number, enabled: boolean) {
+  private determineStatus(originalVals: StickyPositions, pageYOffset: number, marginTop: number, marginBottom: number, enabled: boolean): StickyStatus {
     const elementPos = this.determineElementOffsets();
     let isSticky = enabled && pageYOffset > originalVals.offsetY;
     if (pageYOffset < this.elementOffsetY) {
@@ -241,6 +241,8 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
       isSticky,
       reachedUpperEdge,
       reachedLowerEdge,
+      marginTop,
+      marginBottom,
     };
 
   }


### PR DESCRIPTION
Function `determineStatus` do not return `marginTop` and `marginBottom`, which causes a calculation error for spacer height. `spacerHeight == NaN`