### PR TITLE
resolve issue 70 by using current offsetY

### DIFF
--- a/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
+++ b/projects/angular-sticky-things/src/lib/sticky-thing.directive.ts
@@ -81,7 +81,6 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
   private status$: Observable<StickyStatus>;
 
   private componentDestroyed = new Subject<void>();
-  private elementOffsetY;
 
   constructor(private stickyElement: ElementRef, @Inject(PLATFORM_ID) private platformId: string) {
 
@@ -199,7 +198,6 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     this.checkSetup();
     this.setupListener();
-    this.elementOffsetY = this.determineElementOffsets().offsetY;
   }
 
   ngOnDestroy(): void {
@@ -229,7 +227,7 @@ export class StickyThingDirective implements OnInit, AfterViewInit, OnDestroy {
   private determineStatus(originalVals: StickyPositions, pageYOffset: number, marginTop: number, marginBottom: number, enabled: boolean) {
     const elementPos = this.determineElementOffsets();
     let isSticky = enabled && pageYOffset > originalVals.offsetY;
-    if (pageYOffset < this.elementOffsetY) {
+    if (pageYOffset < elementPos.offsetY) {
       isSticky = false;
     }
     const stickyElementHeight = this.getComputedStyle(this.stickyElement.nativeElement).height;


### PR DESCRIPTION
[issue 70](https://github.com/w11k/angular-sticky-things/issues/70)

Issue 70 was raised because sometimes angular-sticky-things would not work when you came in from a different page, but would work when you reloaded the page. In testing on my site where it was used, when I started on the home page and linked to the profile, the `elementOffsetY` was initialized to the bottom of the page (a y offset of 2121). This happened because the ngOnInit completed before the sticky element was loaded onto the page. If I then refreshed the page, `elementOffsetY` was set to 25 because the ngOnInit waited for all the data to be loaded before completing. I am not sure why the angular lifecycle event was firing different in those circumstances but that was the problem.

This was the code being run in the ngOnInit: `this.elementOffsetY = this.determineElementOffsets().offsetY;`. I noticed that `elementOffsetY` was only used in this method: `determineStatus`. That method was already making a call to `this.determineElementOffsets()` and saving that value. By removing `this.elementOffsetY` and using the saved value of `this.determineElementOffsets()`, that resolved the problem by using the current offsetY of the targeted sticky element.